### PR TITLE
Created condition to ignore the __MACOSX resource fork directory

### DIFF
--- a/PyRearrangeVolumeData/rvd.py
+++ b/PyRearrangeVolumeData/rvd.py
@@ -50,8 +50,9 @@ class Rvd:
           if os.path.isfile(os.path.join(folder,f)):
               return # file is not zipped in a folder
           else : 
-              self.unzipFolder = os.path.join(folder,f) # update the unzipped folder
-              return 
+              if f != "__MACOSX": # directory is not the resource fork
+                self.unzipFolder = os.path.join(folder,f) # update the unzipped folder
+                return 
 
   def DetectHeaderAndPipe(self,filename):
       # some files have the header some not, some are ',' separated some are fixed width


### PR DESCRIPTION
Created condition to ignore the __MACOSX [resource fork](https://en.wikipedia.org/wiki/Resource_fork) directory instead of erroneously setting it as the subdirectory. 

Without this condition, the DetectSubfolder() function would select the __MACOSX directory if it was the first directory returned from os.listdir(). The __MACOSX directory does not contain the expected file structure. 

<img width="822" alt="MACOSX Example" src="https://github.com/policyinfo/TMAS-Traffic-Volume-Data-Rearrangement-Tool/assets/50954077/150b3806-7d53-4dc8-860d-603d3c49432f">

Instead, the DetectSubfolder() function needs to ignore the __MACOSX directory and iterate to the next and correct directory. 

Because os.listdir() does not return directory contents in a specific order, this is not a consistent error. Of the 12 months of data I downloaded for 2022, only 3 zip files were effected. 

